### PR TITLE
Improve #8 by adding another `=>` helper to create StateRoute (conditional transition) using array.

### DIFF
--- a/SwiftState/StateRoute.swift
+++ b/SwiftState/StateRoute.swift
@@ -43,3 +43,32 @@ public struct StateRoute<S: StateType>
         return StateRouteChain(routes: routes)
     }
 }
+
+//--------------------------------------------------
+// MARK: - Custom Operators
+//--------------------------------------------------
+
+/// e.g. [.State0, .State1] => .State2, allowing [0 => 2, 1 => 2]
+public func => <S: StateType>(leftStates: [S], right: S) -> StateRoute<S>
+{
+    // NOTE: don't reuse "nil => nil + condition" for efficiency
+    return StateRoute(transition: nil => right, condition: { transition -> Bool in
+        return contains(leftStates, transition.fromState)
+    })
+}
+
+/// e.g. .State0 => [.State1, .State2], allowing [0 => 1, 0 => 2]
+public func => <S: StateType>(left: S, rightStates: [S]) -> StateRoute<S>
+{
+    return StateRoute(transition: left => nil, condition: { transition -> Bool in
+        return contains(rightStates, transition.toState)
+    })
+}
+
+/// e.g. [.State0, .State1] => [.State2, .State3], allowing [0 => 2, 0 => 3, 1 => 2, 1 => 3]
+public func => <S: StateType>(leftStates: [S], rightStates: [S]) -> StateRoute<S>
+{
+    return StateRoute(transition: nil => nil, condition: { transition -> Bool in
+        return contains(leftStates, transition.fromState) && contains(rightStates, transition.toState)
+    })
+}

--- a/SwiftState/StateTransition.swift
+++ b/SwiftState/StateTransition.swift
@@ -48,7 +48,7 @@ public func == <S: StateType>(left: StateTransition<S>, right: StateTransition<S
 
 infix operator => { associativity left }
 
-// e.g. .State0 => .State1
+/// e.g. .State0 => .State1
 // NOTE: argument types (S) don't need to be optional because it automatically converts nil to Any via NilLiteralConvertible
 public func => <S: StateType>(left: S, right: S) -> StateTransition<S>
 {

--- a/SwiftStateTests/StateMachineTests.swift
+++ b/SwiftStateTests/StateMachineTests.swift
@@ -187,6 +187,63 @@ class StateMachineTests: _TestCase
         XCTAssertEqual(returnedTransition!.toState, MyState.State1)
     }
     
+    // MARK: addRoute using array
+    
+    func testAddRoute_array_left()
+    {
+        let machine = StateMachine<MyState, String>(state: .State0)
+        
+        // add 0 => 2 or 1 => 2
+        machine.addRoute([.State0, .State1] => .State2)
+        
+        XCTAssertFalse(machine.hasRoute(.State0 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State0 => .State1))
+        XCTAssertTrue(machine.hasRoute(.State0 => .State2))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State1))
+        XCTAssertTrue(machine.hasRoute(.State1 => .State2))
+    }
+    
+    func testAddRoute_array_right()
+    {
+        let machine = StateMachine<MyState, String>(state: .State0)
+        
+        // add 0 => 1 or 0 => 2
+        machine.addRoute(.State0 => [.State1, .State2])
+        
+        XCTAssertFalse(machine.hasRoute(.State0 => .State0))
+        XCTAssertTrue(machine.hasRoute(.State0 => .State1))
+        XCTAssertTrue(machine.hasRoute(.State0 => .State2))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State1))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State2))
+    }
+    
+    func testAddRoute_array_both()
+    {
+        let machine = StateMachine<MyState, String>(state: .State0)
+        
+        // add 0 => 2 or 0 => 3 or 1 => 2 or 1 => 3
+        machine.addRoute([MyState.State0, MyState.State1] => [MyState.State2, MyState.State3])
+        
+        XCTAssertFalse(machine.hasRoute(.State0 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State0 => .State1))
+        XCTAssertTrue(machine.hasRoute(.State0 => .State2))
+        XCTAssertTrue(machine.hasRoute(.State0 => .State3))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State1 => .State1))
+        XCTAssertTrue(machine.hasRoute(.State1 => .State2))
+        XCTAssertTrue(machine.hasRoute(.State1 => .State3))
+        XCTAssertFalse(machine.hasRoute(.State2 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State2 => .State1))
+        XCTAssertFalse(machine.hasRoute(.State2 => .State2))
+        XCTAssertFalse(machine.hasRoute(.State2 => .State3))
+        XCTAssertFalse(machine.hasRoute(.State3 => .State0))
+        XCTAssertFalse(machine.hasRoute(.State3 => .State1))
+        XCTAssertFalse(machine.hasRoute(.State3 => .State2))
+        XCTAssertFalse(machine.hasRoute(.State3 => .State3))
+    }
+    
     //--------------------------------------------------
     // MARK: - removeRoute
     //--------------------------------------------------


### PR DESCRIPTION
This pull request will add `.State0 => [.State1, .State2]` StateRouting-helper (using array) to allow 
only for `0 => 1` or `0 => 2` conditional transition, even when new states are added.

Test Case:
[StateMachineTests.swift#L190-L245](https://github.com/ReactKit/SwiftState/blob/db73c10c1cddd2d2a1d79139a259a328cc8aa40b/SwiftStateTests/StateMachineTests.swift#L190-L245)
