### PR TITLE
Migrate SwiftState to Swift 1.2

### DIFF
--- a/SwiftState/HierarchicalStateMachine.swift
+++ b/SwiftState/HierarchicalStateMachine.swift
@@ -61,7 +61,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
     {
         assert(state is HSM.State, "HSM state must be String.")
         
-        let components = split(state as HSM.State, { $0 == "." }, maxSplit: 1)
+        let components = split(state as! HSM.State, { $0 == "." }, maxSplit: 1)
         
         switch components.count {
             case 2:
@@ -85,7 +85,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         let (submachine, substate) = self._submachineTupleForState(self._state)
         
         if let submachine = submachine {
-            self._state = "\(submachine.name).\(submachine.state)" as State
+            self._state = "\(submachine.name).\(submachine.state)" as! State
         }
         
         return self._state
@@ -147,7 +147,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         // try changing submachine-internal state
         if fromSubmachine != nil && toSubmachine != nil && fromSubmachine === toSubmachine {
             
-            if toSubmachine!.canTryState(toSubstate, forEvent: event as HSM.Event) {
+            if toSubmachine!.canTryState(toSubstate, forEvent: event as! HSM.Event) {
                 
                 //
                 // NOTE:

--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -26,11 +26,17 @@ public class StateMachineRouteID<S: StateType, E: StateEventType>
         self.transition = transition
         self.routeKey = routeKey
         self.event = event
+
+        self.bundledRouteIDs = nil
     }
     
     private init(bundledRouteIDs: [StateMachineRouteID<S, E>]?)
     {
         self.bundledRouteIDs = bundledRouteIDs
+
+        self.transition = nil
+        self.routeKey = nil
+        self.event = nil
     }
 }
 
@@ -48,11 +54,16 @@ public class StateMachineHandlerID<S: StateType, E: StateEventType>
     {
         self.transition = transition
         self.handlerKey = handlerKey
+
+        self.bundledHandlerIDs = nil
     }
     
     private init(bundledHandlerIDs: [StateMachineHandlerID<S, E>]?)
     {
         self.bundledHandlerIDs = bundledHandlerIDs
+
+        self.transition = nil
+        self.handlerKey = nil
     }
 }
 
@@ -339,11 +350,6 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRoute(route)
     }
     
-    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool) -> RouteID
-    {
-        return self.addRoute(transition, condition: { t in condition() })
-    }
-    
     public func addRoute(route: Route) -> RouteID
     {
         return self._addRoute(route)
@@ -387,11 +393,6 @@ public class StateMachine<S: StateType, E: StateEventType>
     {
         let route = Route(transition: transition, condition: condition)
         return self.addRoute(route, handler: handler)
-    }
-    
-    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
-    {
-        return self.addRoute(transition, condition: { t in condition() }, handler: handler)
     }
     
     public func addRoute(route: Route, handler: Handler) -> (RouteID, HandlerID)
@@ -621,11 +622,6 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteChain(routeChain, handler: handler)
     }
     
-    public func addRouteChain(chain: TransitionChain, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
-    {
-        return self.addRouteChain(chain, condition: { t in condition() }, handler: handler)
-    }
-    
     public func addRouteChain(chain: RouteChain, handler: Handler) -> (RouteID, HandlerID)
     {
         var routeIDs: [RouteID] = []
@@ -787,11 +783,6 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteEvent(event, routes: routes)
     }
     
-    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool) -> [RouteID]
-    {
-        return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() })
-    }
-    
     public func addRouteEvent(event: Event, routes: [Route]) -> [RouteID]
     {
         var routeIDs: [RouteID] = []
@@ -817,11 +808,6 @@ public class StateMachine<S: StateType, E: StateEventType>
         let handlerID = self.addEventHandler(event, order: self.dynamicType._defaultOrder, handler: handler)
         
         return (routeIDs, handlerID)
-    }
-
-    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool, handler: Handler) -> ([RouteID], HandlerID)
-    {
-        return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() }, handler: handler)
     }
     
     public func addRouteEvent(event: Event, routes: [Route], handler: Handler) -> ([RouteID], HandlerID)

--- a/SwiftState/StateRoute.swift
+++ b/SwiftState/StateRoute.swift
@@ -22,11 +22,6 @@ public struct StateRoute<S: StateType>
         self.condition = condition
     }
     
-    public init(transition: Transition, condition: @autoclosure () -> Bool)
-    {
-        self.init(transition: transition, condition: { t in condition() })
-    }
-    
     public func toTransition() -> Transition
     {
         return self.transition

--- a/SwiftStateTests/StateMachineChainTests.swift
+++ b/SwiftStateTests/StateMachineChainTests.swift
@@ -50,11 +50,13 @@ class StateMachineChainTests: _TestCase
         var invokeCount = 0
         
         // add 0 => 1 => 2
-        machine.addRouteChain(.State0 => .State1 => .State2, condition: flag) { context in
+        machine.addRouteChain(.State0 => .State1 => .State2, condition: { _ -> Bool in
+            return flag
+        }) { (context) -> Void in
             invokeCount++
             return
         }
-        
+
         // tryState 0 => 1 => 2
         machine <- .State1
         machine <- .State2

--- a/SwiftStateTests/StateMachineTests.swift
+++ b/SwiftStateTests/StateMachineTests.swift
@@ -103,7 +103,9 @@ class StateMachineTests: _TestCase
         var flag = false
         
         // add 0 => 1
-        machine.addRoute(.State0 => .State1, condition: flag)
+        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
+            return flag
+        })
         
         XCTAssertFalse(machine.hasRoute(.State0 => .State1))
         
@@ -161,7 +163,9 @@ class StateMachineTests: _TestCase
         machine.addRoute(.State0 => .State1)
         
         // add 0 => 1 with condition + conditionalHandler
-        machine.addRoute(.State0 => .State1, condition: flag) { context in
+        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
+            return flag
+        }) { context in
             returnedTransition = context.transition
         }
         

--- a/SwiftStateTests/StateRouteTests.swift
+++ b/SwiftStateTests/StateRouteTests.swift
@@ -18,7 +18,9 @@ class StateRouteTests: _TestCase
         XCTAssertEqual(route.transition.toState, MyState.State1)
         XCTAssertTrue(route.condition == nil)
         
-        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: false)
+        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: { _ -> Bool in
+            return false
+        })
         XCTAssertEqual(route2.transition.fromState, MyState.State1)
         XCTAssertEqual(route2.transition.toState, MyState.State2)
         XCTAssertTrue(route2.condition != nil)


### PR DESCRIPTION
Hello!

I've migrated SwiftState to Swift 1.2 and now the machine builds and tests are passing under Xcode 6.3 beta.

Unfortunately due to the changes in language I had to cut some features as they are not longer supported by the language. In particular we are affected by changes in autoclosures as described here: http://mazur.me/SwiftInFlux/docs/6.3-beta1.pdf 

> The @autoclosure attribute on parameters now implies the new @noescape attribute. This intentionally 
limits the power of @autoclosure to control-flow and lazy evaluation use cases.

> A new “@noescape” attribute may be used on closure parameters to functions. This indicates that the 
parameter is only ever called (or passed as an @noescape parameter in a call), which means that it cannot 
outlive the lifetime of the call. This enables some minor performance optimizations, but more importantly 
disables the “self.” requirement in closure arguments. This enables control-flow-like functions to be more 
transparent about their behavior. In a future beta, the standard library will adopt this attribute in functions like 
autoreleasepool(). (16323038)

This means that condition autoclosures passed to all ```addRoute*()``` methods cannot be passed and outlive the call. Hope I understood it correctly.

All the other changes are quite minor and I hope make sense. This PR should fix #14 raised by @mkoppanen 