### PR TITLE
Fix code for Xcode6.3 beta2.

### DIFF
--- a/SwiftState/HierarchicalStateMachine.swift
+++ b/SwiftState/HierarchicalStateMachine.swift
@@ -61,7 +61,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
     {
         assert(state is HSM.State, "HSM state must be String.")
         
-        let components = split(state as! HSM.State, { $0 == "." }, maxSplit: 1)
+        let components = split(state as HSM.State, { $0 == "." }, maxSplit: 1)
         
         switch components.count {
             case 2:
@@ -85,7 +85,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         let (submachine, substate) = self._submachineTupleForState(self._state)
         
         if let submachine = submachine {
-            self._state = "\(submachine.name).\(submachine.state)" as! State
+            self._state = "\(submachine.name).\(submachine.state)" as State
         }
         
         return self._state
@@ -147,7 +147,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         // try changing submachine-internal state
         if fromSubmachine != nil && toSubmachine != nil && fromSubmachine === toSubmachine {
             
-            if toSubmachine!.canTryState(toSubstate, forEvent: event as! HSM.Event) {
+            if toSubmachine!.canTryState(toSubstate, forEvent: event as HSM.Event) {
                 
                 //
                 // NOTE:

--- a/SwiftState/HierarchicalStateMachine.swift
+++ b/SwiftState/HierarchicalStateMachine.swift
@@ -61,7 +61,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
     {
         assert(state is HSM.State, "HSM state must be String.")
         
-        let components = split(state as HSM.State, { $0 == "." }, maxSplit: 1)
+        let components = split(state as! HSM.State, maxSplit: 1) { $0 == "." }
         
         switch components.count {
             case 2:
@@ -85,7 +85,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         let (submachine, substate) = self._submachineTupleForState(self._state)
         
         if let submachine = submachine {
-            self._state = "\(submachine.name).\(submachine.state)" as State
+            self._state = "\(submachine.name).\(submachine.state)" as! State
         }
         
         return self._state
@@ -147,7 +147,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         // try changing submachine-internal state
         if fromSubmachine != nil && toSubmachine != nil && fromSubmachine === toSubmachine {
             
-            if toSubmachine!.canTryState(toSubstate, forEvent: event as HSM.Event) {
+            if toSubmachine!.canTryState(toSubstate, forEvent: event as! HSM.Event) {
                 
                 //
                 // NOTE:

--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -26,17 +26,11 @@ public class StateMachineRouteID<S: StateType, E: StateEventType>
         self.transition = transition
         self.routeKey = routeKey
         self.event = event
-
-        self.bundledRouteIDs = nil
     }
     
     private init(bundledRouteIDs: [StateMachineRouteID<S, E>]?)
     {
         self.bundledRouteIDs = bundledRouteIDs
-
-        self.transition = nil
-        self.routeKey = nil
-        self.event = nil
     }
 }
 
@@ -54,16 +48,11 @@ public class StateMachineHandlerID<S: StateType, E: StateEventType>
     {
         self.transition = transition
         self.handlerKey = handlerKey
-
-        self.bundledHandlerIDs = nil
     }
     
     private init(bundledHandlerIDs: [StateMachineHandlerID<S, E>]?)
     {
         self.bundledHandlerIDs = bundledHandlerIDs
-
-        self.transition = nil
-        self.handlerKey = nil
     }
 }
 
@@ -350,6 +339,11 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRoute(route)
     }
     
+    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool) -> RouteID
+    {
+        return self.addRoute(transition, condition: { t in condition() })
+    }
+    
     public func addRoute(route: Route) -> RouteID
     {
         return self._addRoute(route)
@@ -393,6 +387,11 @@ public class StateMachine<S: StateType, E: StateEventType>
     {
         let route = Route(transition: transition, condition: condition)
         return self.addRoute(route, handler: handler)
+    }
+    
+    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
+    {
+        return self.addRoute(transition, condition: { t in condition() }, handler: handler)
     }
     
     public func addRoute(route: Route, handler: Handler) -> (RouteID, HandlerID)
@@ -622,6 +621,11 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteChain(routeChain, handler: handler)
     }
     
+    public func addRouteChain(chain: TransitionChain, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
+    {
+        return self.addRouteChain(chain, condition: { t in condition() }, handler: handler)
+    }
+    
     public func addRouteChain(chain: RouteChain, handler: Handler) -> (RouteID, HandlerID)
     {
         var routeIDs: [RouteID] = []
@@ -783,6 +787,11 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteEvent(event, routes: routes)
     }
     
+    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool) -> [RouteID]
+    {
+        return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() })
+    }
+    
     public func addRouteEvent(event: Event, routes: [Route]) -> [RouteID]
     {
         var routeIDs: [RouteID] = []
@@ -808,6 +817,11 @@ public class StateMachine<S: StateType, E: StateEventType>
         let handlerID = self.addEventHandler(event, order: self.dynamicType._defaultOrder, handler: handler)
         
         return (routeIDs, handlerID)
+    }
+
+    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool, handler: Handler) -> ([RouteID], HandlerID)
+    {
+        return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() }, handler: handler)
     }
     
     public func addRouteEvent(event: Event, routes: [Route], handler: Handler) -> ([RouteID], HandlerID)

--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -26,11 +26,17 @@ public class StateMachineRouteID<S: StateType, E: StateEventType>
         self.transition = transition
         self.routeKey = routeKey
         self.event = event
+        
+        self.bundledRouteIDs = nil
     }
     
     private init(bundledRouteIDs: [StateMachineRouteID<S, E>]?)
     {
         self.bundledRouteIDs = bundledRouteIDs
+        
+        self.transition = nil
+        self.routeKey = nil
+        self.event = nil
     }
 }
 
@@ -48,11 +54,16 @@ public class StateMachineHandlerID<S: StateType, E: StateEventType>
     {
         self.transition = transition
         self.handlerKey = handlerKey
+        
+        self.bundledHandlerIDs = nil
     }
     
     private init(bundledHandlerIDs: [StateMachineHandlerID<S, E>]?)
     {
         self.bundledHandlerIDs = bundledHandlerIDs
+        
+        self.transition = nil
+        self.handlerKey = nil
     }
 }
 
@@ -77,7 +88,7 @@ internal class _StateMachineHandlerInfo<S: StateType, E: StateEventType>
 public class StateMachine<S: StateType, E: StateEventType>
 {
     public typealias HandlerOrder = UInt8
-    public typealias Handler = ((context: HandlerContext) -> Void)
+    public typealias Handler = (HandlerContext -> Void)
     public typealias HandlerContext = (event: Event, transition: Transition, order: HandlerOrder, userInfo: Any?)
     
     internal typealias State = S
@@ -227,7 +238,7 @@ public class StateMachine<S: StateType, E: StateEventType>
                 let order = handlerInfo.order
                 let handler = handlerInfo.handler
                 
-                handler(context: HandlerContext(event: event, transition: transition, order: order, userInfo: userInfo))
+                handler(HandlerContext(event: event, transition: transition, order: order, userInfo: userInfo))
             }
             
             didTransit = true
@@ -237,7 +248,7 @@ public class StateMachine<S: StateType, E: StateEventType>
                 let order = handlerInfo.order
                 let handler = handlerInfo.handler
                 
-                handler(context: HandlerContext(event: event, transition: transition, order: order, userInfo: userInfo))
+                handler(HandlerContext(event: event, transition: transition, order: order, userInfo: userInfo))
             }
         }
         
@@ -339,7 +350,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRoute(route)
     }
     
-    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool) -> RouteID
+    public func addRoute(transition: Transition, @autoclosure(escaping) condition: () -> Bool) -> RouteID
     {
         return self.addRoute(transition, condition: { t in condition() })
     }
@@ -389,7 +400,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRoute(route, handler: handler)
     }
     
-    public func addRoute(transition: Transition, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
+    public func addRoute(transition: Transition, @autoclosure(escaping) condition: () -> Bool, handler: Handler) -> (RouteID, HandlerID)
     {
         return self.addRoute(transition, condition: { t in condition() }, handler: handler)
     }
@@ -404,7 +415,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         let handlerID = self.addHandler(transition) { [weak self] context in
             if let self_ = self {
                 if self_._canPassCondition(condition, transition: context.transition) {
-                    handler(context: context)
+                    handler(context)
                 }
             }
         }
@@ -621,7 +632,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteChain(routeChain, handler: handler)
     }
     
-    public func addRouteChain(chain: TransitionChain, condition: @autoclosure () -> Bool, handler: Handler) -> (RouteID, HandlerID)
+    public func addRouteChain(chain: TransitionChain, @autoclosure(escaping) condition: () -> Bool, handler: Handler) -> (RouteID, HandlerID)
     {
         return self.addRouteChain(chain, condition: { t in condition() }, handler: handler)
     }
@@ -744,7 +755,7 @@ public class StateMachine<S: StateType, E: StateEventType>
             if chainingCount < allCount {
                 shouldStop = true
                 if isError {
-                    handler(context: context)
+                    handler(context)
                 }
             }
         }
@@ -759,7 +770,7 @@ public class StateMachine<S: StateType, E: StateEventType>
                         shouldStop = true
                         
                         if !isError {
-                            handler(context: context)
+                            handler(context)
                         }
                     }
                 }
@@ -787,7 +798,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addRouteEvent(event, routes: routes)
     }
     
-    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool) -> [RouteID]
+    public func addRouteEvent(event: Event, transitions: [Transition], @autoclosure(escaping) condition: () -> Bool) -> [RouteID]
     {
         return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() })
     }
@@ -819,7 +830,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return (routeIDs, handlerID)
     }
 
-    public func addRouteEvent(event: Event, transitions: [Transition], condition: @autoclosure () -> Bool, handler: Handler) -> ([RouteID], HandlerID)
+    public func addRouteEvent(event: Event, transitions: [Transition], @autoclosure(escaping) condition: () -> Bool, handler: Handler) -> ([RouteID], HandlerID)
     {
         return self.addRouteEvent(event, transitions: transitions, condition: { t in condition() }, handler: handler)
     }
@@ -846,7 +857,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         
         let handlerID = self.addHandler(nil => nil, order: order) { [weak self] context in
             if context.event == event {
-                handler(context: context)
+                handler(context)
             }
         }
         

--- a/SwiftState/StateRoute.swift
+++ b/SwiftState/StateRoute.swift
@@ -22,7 +22,7 @@ public struct StateRoute<S: StateType>
         self.condition = condition
     }
     
-    public init(transition: Transition, condition: @autoclosure () -> Bool)
+    public init(transition: Transition, @autoclosure(escaping) condition: () -> Bool)
     {
         self.init(transition: transition, condition: { t in condition() })
     }

--- a/SwiftState/StateRoute.swift
+++ b/SwiftState/StateRoute.swift
@@ -22,6 +22,11 @@ public struct StateRoute<S: StateType>
         self.condition = condition
     }
     
+    public init(transition: Transition, condition: @autoclosure () -> Bool)
+    {
+        self.init(transition: transition, condition: { t in condition() })
+    }
+    
     public func toTransition() -> Transition
     {
         return self.transition

--- a/SwiftStateTests/StateMachineChainTests.swift
+++ b/SwiftStateTests/StateMachineChainTests.swift
@@ -50,13 +50,11 @@ class StateMachineChainTests: _TestCase
         var invokeCount = 0
         
         // add 0 => 1 => 2
-        machine.addRouteChain(.State0 => .State1 => .State2, condition: { _ -> Bool in
-            return flag
-        }) { (context) -> Void in
+        machine.addRouteChain(.State0 => .State1 => .State2, condition: flag) { context in
             invokeCount++
             return
         }
-
+        
         // tryState 0 => 1 => 2
         machine <- .State1
         machine <- .State2

--- a/SwiftStateTests/StateMachineChainTests.swift
+++ b/SwiftStateTests/StateMachineChainTests.swift
@@ -50,7 +50,9 @@ class StateMachineChainTests: _TestCase
         var invokeCount = 0
         
         // add 0 => 1 => 2
-        machine.addRouteChain(.State0 => .State1 => .State2, condition: { _ in flag }) { (context) -> Void in
+        machine.addRouteChain(.State0 => .State1 => .State2, condition: { _ -> Bool in
+            return flag
+        }) { (context) -> Void in
             invokeCount++
             return
         }

--- a/SwiftStateTests/StateMachineTests.swift
+++ b/SwiftStateTests/StateMachineTests.swift
@@ -103,7 +103,9 @@ class StateMachineTests: _TestCase
         var flag = false
         
         // add 0 => 1
-        machine.addRoute(.State0 => .State1, condition: { _ in flag })
+        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
+            return flag
+        })
         
         XCTAssertFalse(machine.hasRoute(.State0 => .State1))
         
@@ -161,7 +163,9 @@ class StateMachineTests: _TestCase
         machine.addRoute(.State0 => .State1)
         
         // add 0 => 1 with condition + conditionalHandler
-        machine.addRoute(.State0 => .State1, condition: { _ in flag }) { context in
+        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
+            return flag
+        }) { context in
             returnedTransition = context.transition
         }
         

--- a/SwiftStateTests/StateMachineTests.swift
+++ b/SwiftStateTests/StateMachineTests.swift
@@ -103,9 +103,7 @@ class StateMachineTests: _TestCase
         var flag = false
         
         // add 0 => 1
-        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
-            return flag
-        })
+        machine.addRoute(.State0 => .State1, condition: flag)
         
         XCTAssertFalse(machine.hasRoute(.State0 => .State1))
         
@@ -163,9 +161,7 @@ class StateMachineTests: _TestCase
         machine.addRoute(.State0 => .State1)
         
         // add 0 => 1 with condition + conditionalHandler
-        machine.addRoute(.State0 => .State1, condition: { _ -> Bool in
-            return flag
-        }) { context in
+        machine.addRoute(.State0 => .State1, condition: flag) { context in
             returnedTransition = context.transition
         }
         

--- a/SwiftStateTests/StateRouteTests.swift
+++ b/SwiftStateTests/StateRouteTests.swift
@@ -18,9 +18,7 @@ class StateRouteTests: _TestCase
         XCTAssertEqual(route.transition.toState, MyState.State1)
         XCTAssertTrue(route.condition == nil)
         
-        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: { _ -> Bool in
-            return false
-        })
+        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: false)
         XCTAssertEqual(route2.transition.fromState, MyState.State1)
         XCTAssertEqual(route2.transition.toState, MyState.State2)
         XCTAssertTrue(route2.condition != nil)

--- a/SwiftStateTests/StateRouteTests.swift
+++ b/SwiftStateTests/StateRouteTests.swift
@@ -18,18 +18,12 @@ class StateRouteTests: _TestCase
         XCTAssertEqual(route.transition.toState, MyState.State1)
         XCTAssertTrue(route.condition == nil)
         
-        //
-        // comment-out: 
-        // `condition` using lazy-evaluated-@autoclosure is removed due to Swift 1.2 change
-        //
-        // From Release Note:
-        // > The @autoclosure attribute on parameters now implies the new @noescape attribute.
-        // > This intentionally limits the power of @autoclosure to control-flow and lazy evaluation use cases.
-        //
-//        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: false)
-//        XCTAssertEqual(route2.transition.fromState, MyState.State1)
-//        XCTAssertEqual(route2.transition.toState, MyState.State2)
-//        XCTAssertTrue(route2.condition != nil)
+        let route2 = StateRoute<MyState>(transition: .State1 => .State2, condition: { _ -> Bool in
+            return false
+        })
+        XCTAssertEqual(route2.transition.fromState, MyState.State1)
+        XCTAssertEqual(route2.transition.toState, MyState.State2)
+        XCTAssertTrue(route2.condition != nil)
         
         let route3 = StateRoute<MyState>(transition: .State2 => .State3, condition: { transition in false })
         XCTAssertEqual(route3.transition.fromState, MyState.State2)


### PR DESCRIPTION
Continuing #16 .

Xcode 6.3 beta 2 now provides `@autoclosure(escaping)` feature,
so we can use this as same as Swift 1.1's plain `@autoclosure`.

There's also some other changes:

- [x] `func split()`'s predicate-closure is now at the last of the argument (probably for trailing closure).
- [x] parameter-named tuple can no longer be used to declare as argument type of handler, i.e. `typealias Handler = ((context: HandlerContext) -> Void)` should now be `typealias Handler = (HandlerContext -> Void)`

@cakper
I decided to revert whole #16 to revive deleted methods. Sorry for that!