### PR TITLE
Fix #20 canTryEvent() bug.

### DIFF
--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -302,7 +302,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         for validEvent in validEvents {
             if let transitionDict = self._routes[validEvent] {
                 for (transition, routeKeyDict) in transitionDict {
-                    if transition.fromState == self.state {
+                    if transition.fromState == self.state || transition.fromState == nil {
                         for (_, condition) in routeKeyDict {
                             if self._canPassCondition(condition, transition: transition) {
                                 return transition.toState

--- a/SwiftStateTests/StateMachineEventTests.swift
+++ b/SwiftStateTests/StateMachineEventTests.swift
@@ -75,6 +75,17 @@ class StateMachineEventTests: _TestCase
         XCTAssertFalse(success, "Event0 doesn't have 2 => Any")
     }
     
+    /// https://github.com/ReactKit/SwiftState/issues/20
+    func testTryEvent_issue20()
+    {
+        let machine = StateMachine<MyState, MyEvent>(state: MyState.State2) { machine in
+            machine.addRouteEvent(.Event0, transitions: [.AnyState => .State0])
+        }
+        
+        XCTAssertTrue(machine <-! .Event0)
+        XCTAssertEqual(machine.state, MyState.State0)
+    }
+    
     func testTryEvent_string()
     {
         let machine = StateMachine<MyState, String>(state: .State0)


### PR DESCRIPTION
Fixes #20.

See [StateMachineEventTests.swift#L78-L87](https://github.com/ReactKit/SwiftState/blob/90fab1f10fc34b5f6b1a54b07dbf31f6685bb64a/SwiftStateTests/StateMachineEventTests.swift#L78-L87) for XCTest.