### PR TITLE
Swift 2.0 support

### DIFF
--- a/SwiftState.xcodeproj/project.pbxproj
+++ b/SwiftState.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Yasuhiro Inami";
 				TargetAttributes = {
 					1FA61FFF1996601000460108 = {
@@ -494,6 +494,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -572,6 +573,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -593,6 +595,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -613,6 +616,7 @@
 				);
 				INFOPLIST_FILE = SwiftStateTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -628,6 +632,7 @@
 				);
 				INFOPLIST_FILE = SwiftStateTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -647,6 +652,7 @@
 				INFOPLIST_FILE = SwiftStateTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "SwiftStateTests-iOS";
 				SDKROOT = iphoneos;
 			};
@@ -662,6 +668,7 @@
 				INFOPLIST_FILE = SwiftStateTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "SwiftStateTests-iOS";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -684,6 +691,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SwiftState/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -703,6 +711,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/SwiftState/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/SwiftState.xcodeproj/project.pbxproj
+++ b/SwiftState.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		1FA61FF71996601000460108 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Yasuhiro Inami";
 				TargetAttributes = {

--- a/SwiftState.xcodeproj/xcshareddata/xcschemes/SwiftState-OSX.xcscheme
+++ b/SwiftState.xcodeproj/xcshareddata/xcschemes/SwiftState-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:SwiftState.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/SwiftState.xcodeproj/xcshareddata/xcschemes/SwiftState-iOS.xcscheme
+++ b/SwiftState.xcodeproj/xcshareddata/xcschemes/SwiftState-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:SwiftState.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/SwiftState/HierarchicalStateMachine.swift
+++ b/SwiftState/HierarchicalStateMachine.swift
@@ -24,7 +24,7 @@ public typealias HSM = HierarchicalStateMachine<String, String>
 //
 
 /// nestable StateMachine with StateType as String
-public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMachine<S, E>, Printable
+public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMachine<S, E>, CustomStringConvertible
 {
     private var _submachines = [String : HSM]()
     
@@ -61,7 +61,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
     {
         assert(state is HSM.State, "HSM state must be String.")
         
-        let components = split(state as! HSM.State, maxSplit: 1) { $0 == "." }
+        let components = split((state as! HSM.State).characters, maxSplit: 1) { $0 == "." }.map { String($0) }
         
         switch components.count {
             case 2:

--- a/SwiftState/HierarchicalStateMachine.swift
+++ b/SwiftState/HierarchicalStateMachine.swift
@@ -82,7 +82,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
     public override var state: State
     {
         // NOTE: returning `substate` is not reliable (as a spec), so replace it with actual `submachine.state` instead
-        let (submachine, substate) = self._submachineTupleForState(self._state)
+        let (submachine, _) = self._submachineTupleForState(self._state)
         
         if let submachine = submachine {
             self._state = "\(submachine.name).\(submachine.state)" as! State
@@ -110,7 +110,7 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         
         let condition: Condition = { transition -> Bool in
             
-            let (fromSubmachine, fromSubstate) = self._submachineTupleForState(route.transition.fromState)
+            let (fromSubmachine, _) = self._submachineTupleForState(route.transition.fromState)
             let (toSubmachine, toSubstate) = self._submachineTupleForState(route.transition.toState)
             
             //
@@ -139,9 +139,9 @@ public class HierarchicalStateMachine<S: StateType, E: StateEventType>: StateMac
         
         let fromState = self.state
         let toState = state
-        let transition = fromState => toState
+        _ = fromState => toState
         
-        let (fromSubmachine, fromSubstate) = self._submachineTupleForState(fromState)
+        let (fromSubmachine, _) = self._submachineTupleForState(fromState)
         let (toSubmachine, toSubstate) = self._submachineTupleForState(toState)
         
         // try changing submachine-internal state

--- a/SwiftState/Info.plist
+++ b/SwiftState/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.inamiy.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -127,7 +127,7 @@ public class StateMachine<S: StateType, E: StateEventType>
     private class func _createUniqueString() -> String
     {
         var uniqueString: String = ""
-        for i in 1...8 {
+        for _ in 1...8 {
             uniqueString += String(UnicodeScalar(arc4random_uniform(0xD800))) // 0xD800 = 55296 = 15.755bit
         }
         return uniqueString
@@ -743,7 +743,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         }
         
         // increment allCount (+ invoke chainErrorHandler) on any routes
-        handlerID = self.addHandler(nil => nil, order: 150) { [weak self] context in
+        handlerID = self.addHandler(nil => nil, order: 150) { context in
             
             shouldIncrementChainingCount = true
             
@@ -852,9 +852,7 @@ public class StateMachine<S: StateType, E: StateEventType>
     
     public func addEventHandler(event: Event, order: HandlerOrder, handler: Handler) -> HandlerID
     {
-        let transitions = self._routes[event]?.keys
-        
-        let handlerID = self.addHandler(nil => nil, order: order) { [weak self] context in
+        let handlerID = self.addHandler(nil => nil, order: order) { context in
             if context.event == event {
                 handler(context)
             }

--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -268,7 +268,7 @@ public class StateMachine<S: StateType, E: StateEventType>
             }
         }
         
-        validHandlerInfos.sort { info1, info2 in
+        validHandlerInfos.sortInPlace { info1, info2 in
             return info1.order < info2.order
         }
         
@@ -504,7 +504,7 @@ public class StateMachine<S: StateType, E: StateEventType>
     {
         var index = handlerInfos.count
         
-        for i in Array(0..<handlerInfos.count).reverse() {
+        for i in Array(Array(0..<handlerInfos.count).reverse()) {
             if handlerInfos[i].order <= newHandlerInfo.order {
                 break
             }
@@ -601,7 +601,7 @@ public class StateMachine<S: StateType, E: StateEventType>
         return self.addErrorHandler(order: self.dynamicType._defaultOrder, handler: handler)
     }
     
-    public func addErrorHandler(#order: HandlerOrder, handler: Handler) -> HandlerID
+    public func addErrorHandler(order order: HandlerOrder, handler: Handler) -> HandlerID
     {
         let handlerKey = self.dynamicType._createUniqueString()
         

--- a/SwiftState/StateRoute.swift
+++ b/SwiftState/StateRoute.swift
@@ -49,7 +49,7 @@ public func => <S: StateType>(leftStates: [S], right: S) -> StateRoute<S>
 {
     // NOTE: don't reuse "nil => nil + condition" for efficiency
     return StateRoute(transition: nil => right, condition: { transition -> Bool in
-        return contains(leftStates, transition.fromState)
+        return leftStates.contains(transition.fromState)
     })
 }
 
@@ -57,7 +57,7 @@ public func => <S: StateType>(leftStates: [S], right: S) -> StateRoute<S>
 public func => <S: StateType>(left: S, rightStates: [S]) -> StateRoute<S>
 {
     return StateRoute(transition: left => nil, condition: { transition -> Bool in
-        return contains(rightStates, transition.toState)
+        return rightStates.contains(transition.toState)
     })
 }
 
@@ -65,6 +65,6 @@ public func => <S: StateType>(left: S, rightStates: [S]) -> StateRoute<S>
 public func => <S: StateType>(leftStates: [S], rightStates: [S]) -> StateRoute<S>
 {
     return StateRoute(transition: nil => nil, condition: { transition -> Bool in
-        return contains(leftStates, transition.fromState) && contains(rightStates, transition.toState)
+        return leftStates.contains(transition.fromState) && rightStates.contains(transition.toState)
     })
 }

--- a/SwiftState/StateTransition.swift
+++ b/SwiftState/StateTransition.swift
@@ -58,7 +58,7 @@ public func => <S: StateType>(left: S, right: S) -> StateTransition<S>
 // MARK: - Printable
 //--------------------------------------------------
 
-extension StateTransition: Printable
+extension StateTransition: CustomStringConvertible
 {
     public var description: String
     {

--- a/SwiftStateTests/BasicTests.swift
+++ b/SwiftStateTests/BasicTests.swift
@@ -16,17 +16,17 @@ class BasicTests: _TestCase
         let machine = StateMachine<MyState, MyEvent>(state: .State0) { machine in
             
             machine.addRoute(.State0 => .State1)
-            machine.addRoute(nil => .State2) { context in println("Any => 2, msg=\(context.userInfo!)") }
-            machine.addRoute(.State2 => nil) { context in println("2 => Any, msg=\(context.userInfo!)") }
+            machine.addRoute(nil => .State2) { context in print("Any => 2, msg=\(context.userInfo!)") }
+            machine.addRoute(.State2 => nil) { context in print("2 => Any, msg=\(context.userInfo!)") }
             
             // add handler (handlerContext = (event, transition, order, userInfo))
             machine.addHandler(.State0 => .State1) { context in
-                println("0 => 1")
+                print("0 => 1")
             }
             
             // add errorHandler
             machine.addErrorHandler { (event, transition, order, userInfo) in
-                println("[ERROR] \(transition.fromState) => \(transition.toState)")
+                print("[ERROR] \(transition.fromState) => \(transition.toState)")
             }
         }
         
@@ -36,7 +36,7 @@ class BasicTests: _TestCase
         machine <- (.State1, "Bye")
         machine <- .State0  // fail: no 1 => 0
         
-        println("machine.state = \(machine.state)")
+        print("machine.state = \(machine.state)")
     }
     
     func testExample()
@@ -45,19 +45,19 @@ class BasicTests: _TestCase
         
             // add 0 => 1
             $0.addRoute(.State0 => .State1) { context in
-                println("[Transition 0=>1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[Transition 0=>1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             // add 0 => 1 once more
             $0.addRoute(.State0 => .State1) { context in
-                println("[Transition 0=>1b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[Transition 0=>1b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             // add 2 => Any
             $0.addRoute(.State2 => nil) { context in
-                println("[Transition exit 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue) (Any)")
+                print("[Transition exit 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue) (Any)")
             }
             // add Any => 2
             $0.addRoute(nil => .State2) { context in
-                println("[Transition Entry 2] \(context.transition.fromState.rawValue) (Any) => \(context.transition.toState.rawValue)")
+                print("[Transition Entry 2] \(context.transition.fromState.rawValue) (Any) => \(context.transition.toState.rawValue)")
             }
             // add 1 => 0 (no handler)
             $0.addRoute(.State1 => .State0)
@@ -94,35 +94,35 @@ class BasicTests: _TestCase
             
             // error
             $0.addErrorHandler { context in
-                println("[ERROR 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[ERROR 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             
             // entry
             $0.addEntryHandler(.State0) { context in
-                println("[Entry 0] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")   // NOTE: this should not be called
+                print("[Entry 0] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")   // NOTE: this should not be called
             }
             $0.addEntryHandler(.State1) { context in
-                println("[Entry 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[Entry 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             $0.addEntryHandler(.State2) { context in
-                println("[Entry 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
+                print("[Entry 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
             }
             $0.addEntryHandler(.State2) { context in
-                println("[Entry 2b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
+                print("[Entry 2b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
             }
             
             // exit
             $0.addExitHandler(.State0) { context in
-                println("[Exit 0] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[Exit 0] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             $0.addExitHandler(.State1) { context in
-                println("[Exit 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
+                print("[Exit 1] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue)")
             }
             $0.addExitHandler(.State2) { context in
-                println("[Exit 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
+                print("[Exit 2] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
             }
             $0.addExitHandler(.State2) { context in
-                println("[Exit 2b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
+                print("[Exit 2b] \(context.transition.fromState.rawValue) => \(context.transition.toState.rawValue), userInfo = \(context.userInfo)")
             }
         }
         

--- a/SwiftStateTests/HierarchicalStateMachineTests.swift
+++ b/SwiftStateTests/HierarchicalStateMachineTests.swift
@@ -160,7 +160,6 @@ class HierarchicalStateMachineTests: _TestCase
     func testAddHandler()
     {
         let mainMachine = self.mainMachine!
-        let sub1Machine = self.sub1Machine!
         
         var didPass = false
         

--- a/SwiftStateTests/HierarchicalStateMachineTests.swift
+++ b/SwiftStateTests/HierarchicalStateMachineTests.swift
@@ -51,12 +51,12 @@ class HierarchicalStateMachineTests: _TestCase
         mainMachine.addRoute("MainState0" => "Sub1.State1")
         
         // add logging handlers
-        sub1Machine.addHandler(nil => nil) { println("[Sub1] \($0.transition)") }
-        sub1Machine.addErrorHandler { println("[ERROR][Sub1] \($0.transition)") }
-        sub2Machine.addHandler(nil => nil) { println("[Sub2] \($0.transition)") }
-        sub2Machine.addErrorHandler { println("[ERROR][Sub2] \($0.transition)") }
-        mainMachine.addHandler(nil => nil) { println("[Main] \($0.transition)") }
-        mainMachine.addErrorHandler { println("[ERROR][Main] \($0.transition)") }
+        sub1Machine.addHandler(nil => nil) { print("[Sub1] \($0.transition)") }
+        sub1Machine.addErrorHandler { print("[ERROR][Sub1] \($0.transition)") }
+        sub2Machine.addHandler(nil => nil) { print("[Sub2] \($0.transition)") }
+        sub2Machine.addErrorHandler { print("[ERROR][Sub2] \($0.transition)") }
+        mainMachine.addHandler(nil => nil) { print("[Main] \($0.transition)") }
+        mainMachine.addErrorHandler { print("[ERROR][Main] \($0.transition)") }
         
         self.mainMachine = mainMachine
         self.sub1Machine = sub1Machine
@@ -166,7 +166,7 @@ class HierarchicalStateMachineTests: _TestCase
         
         // NOTE: this handler is added to mainMachine and doesn't make submachines dirty
         mainMachine.addHandler("Sub1.State1" => "Sub1.State2") { context in
-            println("[Main] 1-1 => 1-2 (specific)")
+            print("[Main] 1-1 => 1-2 (specific)")
             didPass = true
         }
         

--- a/SwiftStateTests/Info.plist
+++ b/SwiftStateTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.inamiy.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftStateTests/MyState.swift
+++ b/SwiftStateTests/MyState.swift
@@ -8,7 +8,7 @@
 
 import SwiftState
 
-enum MyState: Int, StateType, Printable
+enum MyState: Int, StateType, CustomStringConvertible
 {
     case State0, State1, State2, State3
     case AnyState   // IMPORTANT: create case=Any & use it in convertFromNilLiteral()

--- a/SwiftStateTests/StateMachineChainTests.swift
+++ b/SwiftStateTests/StateMachineChainTests.swift
@@ -80,8 +80,6 @@ class StateMachineChainTests: _TestCase
     {
         let machine = StateMachine<MyState, String>(state: .State0)
         
-        var invokeCount = 0
-        
         // add 0 => 1 => 2
         machine.addRouteChain(.State0 => .State1 => .State2) { context in
             XCTFail("Handler should NOT be performed because 0 => 2 is skipping 1.")
@@ -194,7 +192,7 @@ class StateMachineChainTests: _TestCase
         var invokeCount = 0
         
         // add 0 => 1 => 2
-        let (routeID, handlerID) = machine.addRouteChain(.State0 => .State1 => .State2) { context in
+        let (routeID, _) = machine.addRouteChain(.State0 => .State1 => .State2) { context in
             invokeCount++
             return
         }
@@ -216,7 +214,7 @@ class StateMachineChainTests: _TestCase
         var invokeCount = 0
         
         // add 0 => 1 => 2
-        let (routeID, handlerID) = machine.addRouteChain(.State0 => .State1 => .State2) { context in
+        let (_, handlerID) = machine.addRouteChain(.State0 => .State1 => .State2) { context in
             invokeCount++
             return
         }

--- a/SwiftStateTests/StateMachineTests.swift
+++ b/SwiftStateTests/StateMachineTests.swift
@@ -389,14 +389,14 @@ class StateMachineTests: _TestCase
         // add 0 => 1
         machine.addRoute(.State0 => .State1)
         
-        let handlerID = machine.addHandler(.State0 => .State1) { context in
+        machine.addHandler(.State0 => .State1) { context in
             returnedTransition = context.transition
         }
         
         // add 0 => 1 once more
         machine.addRoute(.State0 => .State1)
         
-        let handlerID2 = machine.addHandler(.State0 => .State1) { context in
+        machine.addHandler(.State0 => .State1) { context in
             returnedTransition2 = context.transition
         }
         
@@ -422,6 +422,12 @@ class StateMachineTests: _TestCase
         machine.addHandler(.State0 => .State1) { context in
             returnedTransition = context.transition
         }
+
+        XCTAssertTrue(returnedTransition == nil)
+
+        machine <- .State1
+
+        XCTAssertTrue(returnedTransition != nil)
     }
     
     //--------------------------------------------------
@@ -446,7 +452,7 @@ class StateMachineTests: _TestCase
         // add 0 => 1 once more
         machine.addRoute(.State0 => .State1)
         
-        let handlerID2 = machine.addHandler(.State0 => .State1) { context in
+        machine.addHandler(.State0 => .State1) { context in
             returnedTransition2 = context.transition
         }
         
@@ -495,7 +501,7 @@ class StateMachineTests: _TestCase
         // add 2 => 1 once more
         machine.addRoute(.State2 => .State1)
         
-        let handlerID2 = machine.addErrorHandler { context in
+        machine.addErrorHandler { context in
             returnedTransition2 = context.transition
         }
         

--- a/SwiftStateTests/StateTransitionChainTests.swift
+++ b/SwiftStateTests/StateTransitionChainTests.swift
@@ -61,7 +61,7 @@ class StateTransitionChainTests: _TestCase
     func testPrepend()
     {
         // 0 => 1
-        var transition = MyState.State0 => .State1
+        let transition = MyState.State0 => .State1
         var chain = transition.toTransitionChain()
         
         XCTAssertEqual(chain.numberOfTransitions, 1)

--- a/SwiftStateTests/_TestCase.swift
+++ b/SwiftStateTests/_TestCase.swift
@@ -14,12 +14,12 @@ class _TestCase: XCTestCase
     override func setUp()
     {
         super.setUp()
-        println("\n\n\n")
+        print("\n\n\n")
     }
     
     override func tearDown()
     {
-        println("\n\n\n")
+        print("\n\n\n")
         super.tearDown()
     }
 }


### PR DESCRIPTION
I ran the wizards to clean migrate from Swift 1.2 and cleaned up the warnings. Also changed a test that didn't assert anything.

There's no `swift/2.0` branch so this PR is for master. If you create a Swift 2.0 branch I'll close this PR and open on the new one.

All tests run and pass for the iOS and OS X frameworks.
