### PR TITLE
Fix tryEvent() by never tryState(.AnyState)

### DIFF
--- a/SwiftState/StateMachine.swift
+++ b/SwiftState/StateMachine.swift
@@ -329,7 +329,13 @@ public class StateMachine<S: StateType, E: StateEventType>
     
     public func tryEvent(event: Event, userInfo: Any? = nil) -> Bool
     {
-        if let toState = self.canTryEvent(event) {
+        if var toState = self.canTryEvent(event) {
+            
+            // current state should not be changed if `toState == nil`
+            if toState == nil {
+                toState = self.state
+            }
+            
             self._tryState(toState, userInfo: userInfo, forEvent: event)
             return true
         }

--- a/SwiftStateTests/StateMachineEventTests.swift
+++ b/SwiftStateTests/StateMachineEventTests.swift
@@ -86,6 +86,31 @@ class StateMachineEventTests: _TestCase
         XCTAssertEqual(machine.state, MyState.State0)
     }
     
+    /// https://github.com/ReactKit/SwiftState/issues/28
+    func testTryEvent_issue28()
+    {
+        var eventCount = 0
+        let machine = StateMachine<MyState, MyEvent>(state: .State0) { machine in
+            machine.addRoute(.State0 => .State1)
+            machine.addRouteEvent(.Event0, transitions: [nil => nil]) { _ in
+                eventCount++
+            }
+        }
+        
+        XCTAssertEqual(eventCount, 0)
+        
+        machine <-! .Event0
+        XCTAssertEqual(eventCount, 1)
+        XCTAssertEqual(machine.state, MyState.State0, "State should NOT be changed")
+        
+        machine <- .State1
+        XCTAssertEqual(machine.state, MyState.State1, "State should be changed")
+        
+        machine <-! .Event0
+        XCTAssertEqual(eventCount, 2)
+        XCTAssertEqual(machine.state, MyState.State1, "State should NOT be changed")
+    }
+    
     func testTryEvent_string()
     {
         let machine = StateMachine<MyState, String>(state: .State0)


### PR DESCRIPTION
This pull request will fix `tryEvent()` where `toState` (finished state) might become as `.AnyState`.

This fix will also allow #28 to trigger event without changing `StateMachine`'s internal state, i.e.:

```
machine.addRouteEvent(.SomeEvent, transitions: [nil => nil], handler: {...})
machine <-! .SomeEvent  // handler should be called from any states, and should not change state
```
