### PR TITLE
Add support for watchOS deployment target

### DIFF
--- a/SwiftState.podspec
+++ b/SwiftState.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = '10.9'
   s.ios.deployment_target = '8.0'
+  s.watchos.deployment_target = '2.0'
 end


### PR DESCRIPTION
Adding support for watchOS Deployment Target so state machine logic can be passed though to WatchKit Extensions.
