### PR TITLE
Do not use hashValue in comparison

### DIFF
--- a/Sources/EventType.swift
+++ b/Sources/EventType.swift
@@ -63,12 +63,22 @@ public func == <E: EventType>(lhs: Event<E>, rhs: Event<E>) -> Bool
 
 public func == <E: EventType>(lhs: Event<E>, rhs: E) -> Bool
 {
-    return lhs.hashValue == rhs.hashValue
+    switch lhs {
+    case .Some(let x):
+        return x == rhs
+    case .Any:
+        return false
+    }
 }
 
 public func == <E: EventType>(lhs: E, rhs: Event<E>) -> Bool
 {
-    return lhs.hashValue == rhs.hashValue
+    switch rhs {
+    case .Some(let x):
+        return x == lhs
+    case .Any:
+        return false
+    }
 }
 
 // MARK: NoEvent

--- a/Sources/StateType.swift
+++ b/Sources/StateType.swift
@@ -51,17 +51,34 @@ extension State: RawRepresentable
 
 public func == <S: StateType>(lhs: State<S>, rhs: State<S>) -> Bool
 {
-    return lhs.hashValue == rhs.hashValue
+    switch (lhs, rhs) {
+    case let (.Some(x1), .Some(x2)) where x1 == x2:
+        return true
+    case (.Any, .Any):
+        return true
+    default:
+        return false
+    }
 }
 
 public func == <S: StateType>(lhs: State<S>, rhs: S) -> Bool
 {
-    return lhs.hashValue == rhs.hashValue
+    switch lhs {
+    case .Some(let x):
+        return x == rhs
+    case .Any:
+        return false
+    }
 }
 
 public func == <S: StateType>(lhs: S, rhs: State<S>) -> Bool
 {
-    return lhs.hashValue == rhs.hashValue
+    switch rhs {
+    case .Some(let x):
+        return x == lhs
+    case .Any:
+        return false
+    }
 }
 
 // MARK: Private

--- a/Sources/Transition.swift
+++ b/Sources/Transition.swift
@@ -45,7 +45,7 @@ public struct Transition<S: StateType>: Hashable
 // for Transition Equatable
 public func == <S: StateType>(left: Transition<S>, right: Transition<S>) -> Bool
 {
-    return left.hashValue == right.hashValue
+    return left.fromState == right.fromState && left.toState == right.toState
 }
 
 //--------------------------------------------------


### PR DESCRIPTION
Hi @inamiy,

First of all, thank you for creating this amazing library!

When exploring the codebase, I found that `hashValue`s are used in comparison in a few places. This seems a logic error: [`x == y` implies `x.hashValue == y.hashValue`](https://developer.apple.com/library/tvos/documentation/Swift/Reference/Swift_Hashable_Protocol/index.html), but not the other way around. Therefore, using `hashValue` in comparison, technically speaking, is not reliable because of potential hash collision.

I understand that in many cases, we are comparing two hash value generated by SwiftState classes, and hash collision is unlikely/impossible. However, the concrete Event/State types will be implemented by the client (user of SwiftState), so there is no way to guarantee that hash collision won't happen.

I have removed all occurrences of comparison of `hashValue`s, and reimplemented them using plain old pattern matching. Please let me know your thoughts on this.
