### PR TITLE
Adds @escaping where required for Swift 3.0 GM

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -34,7 +34,7 @@ public final class ActionDisposable: Disposable {
     }
 
     /// Initializes the disposable to run the given action upon disposal.
-    public init(action: (() -> ())) {
+    public init(action: @escaping (() -> ())) {
         self.action = action
     }
 

--- a/Sources/Machine.swift
+++ b/Sources/Machine.swift
@@ -293,26 +293,26 @@ public class Machine<S: StateType, E: EventType>
     // MARK: addRoutes(event:) + conditional handler
 
     @discardableResult
-    public func addRoutes(event: E, transitions: [Transition<S>], condition: Condition? = nil, handler: Handler) -> Disposable
+    public func addRoutes(event: E, transitions: [Transition<S>], condition: Condition? = nil, handler: @escaping Handler) -> Disposable
     {
         return self.addRoutes(event: .some(event), transitions: transitions, condition: condition, handler: handler)
     }
 
     @discardableResult
-    public func addRoutes(event: Event<E>, transitions: [Transition<S>], condition: Condition? = nil, handler: Handler) -> Disposable
+    public func addRoutes(event: Event<E>, transitions: [Transition<S>], condition: Condition? = nil, handler: @escaping Handler) -> Disposable
     {
         let routes = transitions.map { Route(transition: $0, condition: condition) }
         return self.addRoutes(event: event, routes: routes, handler: handler)
     }
 
     @discardableResult
-    public func addRoutes(event: E, routes: [Route<S, E>], handler: Handler) -> Disposable
+    public func addRoutes(event: E, routes: [Route<S, E>], handler: @escaping Handler) -> Disposable
     {
         return self.addRoutes(event: .some(event), routes: routes, handler: handler)
     }
 
     @discardableResult
-    public func addRoutes(event: Event<E>, routes: [Route<S, E>], handler: Handler) -> Disposable
+    public func addRoutes(event: Event<E>, routes: [Route<S, E>], handler: @escaping Handler) -> Disposable
     {
         let routeDisposable = self.addRoutes(event: event, routes: routes)
         let handlerDisposable = self.addHandler(event: event, handler: handler)
@@ -367,7 +367,7 @@ public class Machine<S: StateType, E: EventType>
     // MARK: addRouteMapping
 
     @discardableResult
-    public func addRouteMapping(_ routeMapping: RouteMapping) -> Disposable
+    public func addRouteMapping(_ routeMapping: @escaping RouteMapping) -> Disposable
     {
         let key = _createUniqueString()
 
@@ -383,7 +383,7 @@ public class Machine<S: StateType, E: EventType>
     // MARK: addRouteMapping + conditional handler
 
     @discardableResult
-    public func addRouteMapping(_ routeMapping: RouteMapping, order: HandlerOrder = _defaultOrder, handler: Machine.Handler) -> Disposable
+    public func addRouteMapping(_ routeMapping: @escaping RouteMapping, order: HandlerOrder = _defaultOrder, handler: @escaping Machine.Handler) -> Disposable
     {
         let routeDisposable = self.addRouteMapping(routeMapping)
 
@@ -425,13 +425,13 @@ public class Machine<S: StateType, E: EventType>
     // MARK: addHandler(event:)
 
     @discardableResult
-    public func addHandler(event: E, order: HandlerOrder = _defaultOrder, handler: Machine.Handler) -> Disposable
+    public func addHandler(event: E, order: HandlerOrder = _defaultOrder, handler: @escaping Machine.Handler) -> Disposable
     {
         return self.addHandler(event: .some(event), order: order, handler: handler)
     }
 
     @discardableResult
-    public func addHandler(event: Event<E>, order: HandlerOrder = _defaultOrder, handler: Machine.Handler) -> Disposable
+    public func addHandler(event: Event<E>, order: HandlerOrder = _defaultOrder, handler: @escaping Machine.Handler) -> Disposable
     {
         return self._addHandler(event: event, order: order) { context in
             // skip if not event-based transition
@@ -446,7 +446,7 @@ public class Machine<S: StateType, E: EventType>
     }
 
     @discardableResult
-    private func _addHandler(event: Event<E>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    private func _addHandler(event: Event<E>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         if self._handlers[event] == nil {
             self._handlers[event] = []
@@ -470,7 +470,7 @@ public class Machine<S: StateType, E: EventType>
     // MARK: addErrorHandler
 
     @discardableResult
-    public func addErrorHandler(order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addErrorHandler(order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         let key = _createUniqueString()
 

--- a/Sources/StateMachine.swift
+++ b/Sources/StateMachine.swift
@@ -215,14 +215,14 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addRoute (no-event) + conditional handler
 
     @discardableResult
-    public func addRoute(_ transition: Transition<S>, condition: Condition? = nil, handler: Handler) -> Disposable
+    public func addRoute(_ transition: Transition<S>, condition: Condition? = nil, handler: @escaping Handler) -> Disposable
     {
         let route = Route(transition: transition, condition: condition)
         return self.addRoute(route, handler: handler)
     }
 
     @discardableResult
-    public func addRoute(_ route: Route<S, E>, handler: Handler) -> Disposable
+    public func addRoute(_ route: Route<S, E>, handler: @escaping Handler) -> Disposable
     {
         let transition = route.transition
         let condition = route.condition
@@ -278,7 +278,7 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     /// Add `handler` that is called when `tryState()` succeeds for target `transition`.
     /// - Note: `handler` will not be invoked for `tryEvent()`.
     @discardableResult
-    public func addHandler(_ transition: Transition<S>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addHandler(_ transition: Transition<S>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         if self._handlers[transition] == nil {
             self._handlers[transition] = []
@@ -322,7 +322,7 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
 
     /// Add `handler` that is called when either `tryEvent()` or `tryState()` succeeds for target `transition`.
     @discardableResult
-    public func addAnyHandler(_ transition: Transition<S>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addAnyHandler(_ transition: Transition<S>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         let disposable1 = self.addHandler(transition, order: order, handler: handler)
         let disposable2 = self.addHandler(event: .any, order: order) { context in
@@ -351,14 +351,14 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addRouteChain + conditional handler
 
     @discardableResult
-    public func addRouteChain(_ chain: TransitionChain<S>, condition: Condition? = nil, handler: Handler) -> Disposable
+    public func addRouteChain(_ chain: TransitionChain<S>, condition: Condition? = nil, handler: @escaping Handler) -> Disposable
     {
         let routeChain = RouteChain(transitionChain: chain, condition: condition)
         return self.addRouteChain(routeChain, handler: handler)
     }
 
     @discardableResult
-    public func addRouteChain(_ chain: RouteChain<S, E>, handler: Handler) -> Disposable
+    public func addRouteChain(_ chain: RouteChain<S, E>, handler: @escaping Handler) -> Disposable
     {
         let routeDisposables = chain.routes.map { self.addRoute($0) }
         let handlerDisposable = self.addChainHandler(chain, handler: handler)
@@ -372,13 +372,13 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addChainHandler
 
     @discardableResult
-    public func addChainHandler(_ chain: TransitionChain<S>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addChainHandler(_ chain: TransitionChain<S>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         return self.addChainHandler(RouteChain(transitionChain: chain), order: order, handler: handler)
     }
 
     @discardableResult
-    public func addChainHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addChainHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         return self._addChainHandler(chain, order: order, handler: handler, isError: false)
     }
@@ -386,19 +386,19 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addChainErrorHandler
 
     @discardableResult
-    public func addChainErrorHandler(_ chain: TransitionChain<S>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addChainErrorHandler(_ chain: TransitionChain<S>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         return self.addChainErrorHandler(RouteChain(transitionChain: chain), order: order, handler: handler)
     }
 
     @discardableResult
-    public func addChainErrorHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: Handler) -> Disposable
+    public func addChainErrorHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler) -> Disposable
     {
         return self._addChainHandler(chain, order: order, handler: handler, isError: true)
     }
 
     @discardableResult
-    private func _addChainHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: Handler, isError: Bool) -> Disposable
+    private func _addChainHandler(_ chain: RouteChain<S, E>, order: HandlerOrder = _defaultOrder, handler: @escaping Handler, isError: Bool) -> Disposable
     {
         var handlerDisposables: [Disposable] = []
 
@@ -483,7 +483,7 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addStateRouteMapping
 
     @discardableResult
-    public func addStateRouteMapping(_ routeMapping: StateRouteMapping) -> Disposable
+    public func addStateRouteMapping(_ routeMapping: @escaping StateRouteMapping) -> Disposable
     {
         let key = _createUniqueString()
 
@@ -499,7 +499,7 @@ public final class StateMachine<S: StateType, E: EventType>: Machine<S, E>
     // MARK: addStateRouteMapping + conditional handler
 
     @discardableResult
-    public func addStateRouteMapping(_ routeMapping: StateRouteMapping, handler: Handler) -> Disposable
+    public func addStateRouteMapping(_ routeMapping: @escaping StateRouteMapping, handler: @escaping Handler) -> Disposable
     {
         let routeDisposable = self.addStateRouteMapping(routeMapping)
 

--- a/Sources/_HandlerInfo.swift
+++ b/Sources/_HandlerInfo.swift
@@ -12,7 +12,7 @@ internal final class _HandlerInfo<S: StateType, E: EventType>
     internal let key: String
     internal let handler: Machine<S, E>.Handler
 
-    internal init(order: HandlerOrder, key: String, handler: Machine<S, E>.Handler)
+    internal init(order: HandlerOrder, key: String, handler: @escaping Machine<S, E>.Handler)
     {
         self.order = order
         self.key = key


### PR DESCRIPTION
This change fixes all errors while building with Swift 3.0 GM from Xcode 8 GM
