### PR TITLE
Use arc4random_uniform() across platforms

### DIFF
--- a/Sources/_Random.swift
+++ b/Sources/_Random.swift
@@ -14,7 +14,7 @@ import Glibc
 
 internal func _random(_ upperBound: Int) -> Int
 {
-    #if os(OSX) || os(iOS)
+    #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
     return Int(arc4random_uniform(UInt32(upperBound)))
     #else
     return Int(random() % upperBound)


### PR DESCRIPTION
With Xcode 8.1, compilation fails on watchOS and tvOS targets, as random() is no longer available. This in turn causes Carthage builds to fail (as it tries to build the watchOS and tvOS targets as well). 