### PR TITLE
Replace Machine.Context tuple with a struct

### DIFF
--- a/Sources/Machine.swift
+++ b/Sources/Machine.swift
@@ -17,7 +17,13 @@
 public class Machine<S: StateType, E: EventType>
 {
     /// Closure argument for `Condition` & `Handler`.
-    public typealias Context = (event: E?, fromState: S, toState: S, userInfo: Any?)
+    public struct Context
+    {
+        public let event: E?
+        public let fromState: S
+        public let toState: S
+        public let userInfo: Any?
+    }
 
     /// Closure for validating transition.
     /// If condition returns `false`, transition will fail and associated handlers will not be invoked.
@@ -569,7 +575,7 @@ internal func _validTransitions<S>(fromState: S, toState: S) -> [Transition<S>]
 
 internal func _canPassCondition<S:StateType, E:EventType>(_ condition: Machine<S, E>.Condition?, forEvent event: E?, fromState: S, toState: S, userInfo: Any?) -> Bool
 {
-    return condition?((event, fromState, toState, userInfo)) ?? true
+    return condition?(Machine<S, E>.Context(event: event, fromState: fromState, toState: toState, userInfo: userInfo)) ?? true
 }
 
 internal func _insertHandlerIntoArray<S, E>(_ handlerInfos: inout [_HandlerInfo<S, E>], newHandlerInfo: _HandlerInfo<S, E>)

--- a/SwiftState.xcodeproj/project.pbxproj
+++ b/SwiftState.xcodeproj/project.pbxproj
@@ -236,7 +236,8 @@
 				5243E3C71E9821E200D031A9 /* TransitionChainTests.swift */,
 				5243E3C81E9821E200D031A9 /* TransitionTests.swift */,
 			);
-			path = SwiftStateTests;
+			name = SwiftStateTests;
+			path = Tests/SwiftStateTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -555,7 +556,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = SwiftStateTests/Info.plist;
+				INFOPLIST_FILE = Tests/SwiftStateTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
@@ -571,7 +572,7 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = SwiftStateTests/Info.plist;
+				INFOPLIST_FILE = Tests/SwiftStateTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;

--- a/Tests/SwiftStateTests/BasicTests.swift
+++ b/Tests/SwiftStateTests/BasicTests.swift
@@ -26,8 +26,8 @@ class BasicTests: _TestCase
             }
 
             // add errorHandler
-            machine.addErrorHandler { event, fromState, toState, userInfo in
-                print("[ERROR] \(fromState) => \(toState)")
+            machine.addErrorHandler { context in
+                print("[ERROR] \(context.fromState) => \(context.toState)")
             }
         }
 

--- a/Tests/SwiftStateTests/HierarchicalMachineTests.swift
+++ b/Tests/SwiftStateTests/HierarchicalMachineTests.swift
@@ -92,9 +92,9 @@ class HierarchicalMachineTests: _TestCase
         let mainMachine = StateMachine<_MainState, NoEvent>(state: .mainState0) { mainMachine in
 
             // add routes & handle for same-subMachine internal transitions
-            mainMachine.addRoute(.any => .any, condition: { _, fromState, toState, userInfo in
+            mainMachine.addRoute(.any => .any, condition: { context in
 
-                switch (fromState, toState) {
+                switch (context.fromState, context.toState) {
                     case let (.subMachine1(state1), .subMachine1(state2)):
                         return subMachine1.hasRoute(fromState: state1, toState: state2)
                     case let (.subMachine2(state1), .subMachine2(state2)):
@@ -103,8 +103,8 @@ class HierarchicalMachineTests: _TestCase
                         return false
                 }
 
-            }, handler: { _, fromState, toState, userInfo in
-                switch (fromState, toState) {
+            }, handler: { context in
+                switch (context.fromState, context.toState) {
                     case let (.subMachine1, .subMachine1(state2)):
                         subMachine1 <- state2
                     case let (.subMachine2, .subMachine2(state2)):

--- a/Tests/SwiftStateTests/MachineTests.swift
+++ b/Tests/SwiftStateTests/MachineTests.swift
@@ -341,7 +341,7 @@ class MachineTests: _TestCase
 
         let machine = Machine<MyState, MyEvent>(state: .state0) { machine in
             machine.addRoutes(event: .event0, transitions: [ .state0 => .state1 ])
-            machine.addErrorHandler { event, fromState, toState, userInfo in
+            machine.addErrorHandler { _ in
                 invokeCount += 1
             }
         }

--- a/Tests/SwiftStateTests/MiscTests.swift
+++ b/Tests/SwiftStateTests/MiscTests.swift
@@ -26,8 +26,8 @@ class MiscTests: _TestCase
             }
 
             // add errorHandler
-            machine.addErrorHandler { event, fromState, toState, userInfo in
-                print("[ERROR] \(fromState) => \(toState)")
+            machine.addErrorHandler { context in
+                print("[ERROR] \(context.fromState) => \(context.toState)")
             }
         }
 
@@ -63,8 +63,8 @@ class MiscTests: _TestCase
             }
 
             // add errorHandler
-            machine.addErrorHandler { event, fromState, toState, userInfo in
-                print("[ERROR] \(fromState) => \(toState)")
+            machine.addErrorHandler { context in
+                print("[ERROR] \(context.fromState) => \(context.toState)")
             }
         }
 

--- a/Tests/SwiftStateTests/RouteMappingTests.swift
+++ b/Tests/SwiftStateTests/RouteMappingTests.swift
@@ -98,7 +98,7 @@ class RouteMappingTests: _TestCase
             }
 
             // increment `count` when any events i.e. `.cancelAction` and `.loadAction(x)` succeed.
-            machine.addHandler(event: .any) { event, transition, order, userInfo in
+            machine.addHandler(event: .any) { _ in
                 count += 1
             }
 
@@ -153,7 +153,7 @@ class RouteMappingTests: _TestCase
             }
 
             // increment `count` when any events i.e. `.cancelAction` and `.loadAction(x)` succeed.
-            machine.addHandler(.any => .any) { event, transition, order, userInfo in
+            machine.addHandler(.any => .any) { _ in
                 count += 1
             }
 


### PR DESCRIPTION
Allows Machine.Context to be extended. Tuples, as non-nominal types, can’t be extended.