### PR TITLE
Add Build Option 'Require Only App-Extension-Safe API'

### DIFF
--- a/SwiftState.xcodeproj/project.pbxproj
+++ b/SwiftState.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1FD79F971C1736D600CE7060 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -527,6 +528,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1FD79F971C1736D600CE7060 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Add the 'Require Only App-Extension-Safe API' build option in order to allow using SwiftState in App Extensions without receiving warnings